### PR TITLE
Generalize data paths for any data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,20 @@ export PYTHONPATH=$PWD:$PYTHONPATH
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 ```
 
-- Train on the unified generator on cars, motorbikes or chair (Improved generator in
-  Appendix):
+- Train the unified generator on cars, motorbikes or chair (Improved generator in Appendix):
 
 ```bash
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=40 --data_camera_mode shapenet_car  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=80 --data_camera_mode shapenet_motorbike  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=400 --data_camera_mode shapenet_chair  --dmtet_scale 0.8  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/02958343 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=40 --manifest_dir shapenet_car  --dmtet_scale 1.0 --one_3d_generator 1  --fp32 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/03790512 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=80 --manifest_dir shapenet_motorbike  --dmtet_scale 1.0 --one_3d_generator 1  --fp32 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/03001627 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=400 --manifest_dir shapenet_chair  --dmtet_scale 0.8 --one_3d_generator 1  --fp32 0
 ```
 
-- If want to train on seperate generators (main Figure in the paper):
+- If want to train on separate generators (main Figure in the paper):
 
 ```bash
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=40 --data_camera_mode shapenet_car  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 0
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=80 --data_camera_mode shapenet_motorbike  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 0
-python train_3d.py --outdir=PATH_TO_LOG --data=PATH_TO_RENDER_IMG --camera_path PATH_TO_RENDER_CAMERA --gpus=8 --batch=32 --gamma=3200 --data_camera_mode shapenet_chair  --dmtet_scale 0.8  --use_shapenet_split 1  --one_3d_generator 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/02958343 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=40 --manifest_dir shapenet_car  --dmtet_scale 1.0 --one_3d_generator 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/03790512 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=80 --manifest_dir shapenet_motorbike  --dmtet_scale 1.0 --one_3d_generator 0
+python train_3d.py --outdir=./logs --data=./shapenet/img/03001627 --camera_path=./shapenet/camera --gpus=8 --batch=32 --gamma=400 --manifest_dir shapenet_chair  --dmtet_scale 0.8 --one_3d_generator 0
 ```
 
 If want to debug the model first, reduce the number of gpus to 1 and batch size to 4 via:
@@ -123,9 +122,9 @@ If want to debug the model first, reduce the number of gpus to 1 and batch size 
 - Inference could operate on a single GPU with 16 GB memory.
 
 ```bash
-python train_3d.py --outdir=save_inference_results/shapenet_car  --gpus=1 --batch=4 --gamma=40 --data_camera_mode shapenet_car  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
-python train_3d.py --outdir=save_inference_results/shapenet_chair  --gpus=1 --batch=4 --gamma=40 --data_camera_mode shapenet_chair  --dmtet_scale 0.8  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
-python train_3d.py --outdir=save_inference_results/shapenet_motorbike  --gpus=1 --batch=4 --gamma=40 --data_camera_mode shapenet_motorbike  --dmtet_scale 1.0  --use_shapenet_split 1  --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
+python train_3d.py --outdir=save_inference_results/shapenet_car  --gpus=1 --batch=4 --gamma=40 --manifest_dir shapenet_car  --dmtet_scale 1.0 --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
+python train_3d.py --outdir=save_inference_results/shapenet_chair  --gpus=1 --batch=4 --gamma=40 --manifest_dir shapenet_chair  --dmtet_scale 0.8 --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
+python train_3d.py --outdir=save_inference_results/shapenet_motorbike  --gpus=1 --batch=4 --gamma=40 --manifest_dir shapenet_motorbike  --dmtet_scale 1.0 --one_3d_generator 1  --fp32 0 --inference_vis 1 --resume_pretrain MODEL_PATH
 ```
 
 - To generate mesh with textures, add one option to the inference

--- a/train_3d.py
+++ b/train_3d.py
@@ -22,13 +22,10 @@ from training import inference_3d
 
 # ----------------------------------------------------------------------------
 def subprocess_fn(rank, c, temp_dir):
-    print('Subprocess...1')
     dnnlib.util.Logger(file_name=os.path.join(c.run_dir, 'log.txt'), file_mode='a', should_flush=True)
-    print('Subprocess...2')
 
     # Init torch.distributed.
     if c.num_gpus > 1:
-        print('Subprocess...3')
         init_file = os.path.abspath(os.path.join(temp_dir, '.torch_distributed_init'))
         if os.name == 'nt':
             init_method = 'file:///' + init_file.replace('\\', '/')
@@ -38,10 +35,8 @@ def subprocess_fn(rank, c, temp_dir):
             init_method = f'file://{init_file}'
             torch.distributed.init_process_group(
                 backend='nccl', init_method=init_method, rank=rank, world_size=c.num_gpus)
-    print('Subprocess...4')
     # Init torch_utils.
     sync_device = torch.device('cuda', rank) if c.num_gpus > 1 else None
-    print('Subprocess...5')
     training_stats.init_multiprocessing(rank=rank, sync_device=sync_device)
     if rank != 0:
         custom_ops.verbosity = 'none'
@@ -100,15 +95,11 @@ def launch_training(c, desc, outdir, dry_run):
         json.dump(c, f, indent=2)
 
     # Launch processes.
-    print('Launching processes...')
     torch.multiprocessing.set_start_method('spawn', force=True)
-    print('Launching processes...2')
-
     with tempfile.TemporaryDirectory() as temp_dir:
         if c.num_gpus == 1:
             subprocess_fn(rank=0, c=c, temp_dir=temp_dir)
         else:
-            print('Launching processes...3')
             torch.multiprocessing.spawn(fn=subprocess_fn, args=(c, temp_dir), nprocs=c.num_gpus)
 
 

--- a/train_3d.py
+++ b/train_3d.py
@@ -35,6 +35,7 @@ def subprocess_fn(rank, c, temp_dir):
             init_method = f'file://{init_file}'
             torch.distributed.init_process_group(
                 backend='nccl', init_method=init_method, rank=rank, world_size=c.num_gpus)
+
     # Init torch_utils.
     sync_device = torch.device('cuda', rank) if c.num_gpus > 1 else None
     training_stats.init_multiprocessing(rank=rank, sync_device=sync_device)
@@ -95,6 +96,7 @@ def launch_training(c, desc, outdir, dry_run):
         json.dump(c, f, indent=2)
 
     # Launch processes.
+    print('Launching processes...')
     torch.multiprocessing.set_start_method('spawn', force=True)
     with tempfile.TemporaryDirectory() as temp_dir:
         if c.num_gpus == 1:

--- a/training/dataset.py
+++ b/training/dataset.py
@@ -207,15 +207,15 @@ class ImageFolderDataset(Dataset):
             self.img_list = all_img_list
             self.mask_list = all_mask_list
 
-            self.img_size = resolution
-            self._type = 'dir'
-            self._all_fnames = self.img_list
-            self._image_fnames = self._all_fnames
-            name = os.path.splitext(os.path.basename(self._path))[0]
-            print(
-                '==> use image path: %s, num images: %d' % (self.root, len(self._all_fnames)))
-            raw_shape = [len(self._image_fnames)] + list(self._load_raw_image(0).shape)
-            super().__init__(name=name, raw_shape=raw_shape, **super_kwargs)
+        self.img_size = resolution
+        self._type = 'dir'
+        self._all_fnames = self.img_list
+        self._image_fnames = self._all_fnames
+        name = os.path.splitext(os.path.basename(self._path))[0]
+        print(
+            '==> use image path: %s, num images: %d' % (self.root, len(self._all_fnames)))
+        raw_shape = [len(self._image_fnames)] + list(self._load_raw_image(0).shape)
+        super().__init__(name=name, raw_shape=raw_shape, **super_kwargs)
 
     @staticmethod
     def _file_ext(fname):

--- a/training/loss.py
+++ b/training/loss.py
@@ -105,15 +105,7 @@ class StyleGAN2Loss(Loss):
                     gen_z, gen_c, return_shape=True
                 )
 
-                camera_condition = None
-                if self.G.synthesis.data_camera_mode == 'shapenet_car' or self.G.synthesis.data_camera_mode == 'shapenet_chair' \
-                        or self.G.synthesis.data_camera_mode == 'shapenet_motorbike' or self.G.synthesis.data_camera_mode == 'renderpeople' or \
-                        self.G.synthesis.data_camera_mode == 'shapenet_plant' or self.G.synthesis.data_camera_mode == 'shapenet_vase' or \
-                        self.G.synthesis.data_camera_mode == 'ts_house' or self.G.synthesis.data_camera_mode == 'ts_animal' or \
-                        self.G.synthesis.data_camera_mode == 'all_shapenet':
-                    camera_condition = torch.cat((gen_camera[-2], gen_camera[-1]), dim=-1)
-                else:
-                    assert NotImplementedError
+                camera_condition = torch.cat((gen_camera[-2], gen_camera[-1]), dim=-1)
                 # Send to discriminator
                 gen_logits = self.run_D(gen_img, camera_condition, mask_pyramid=mask_pyramid)
                 gen_logits, gen_logits_mask = gen_logits
@@ -150,14 +142,8 @@ class StyleGAN2Loss(Loss):
                 # First generate the rendered image of generated 3D shapes
                 gen_img, _gen_ws, gen_camera, mask_pyramid, render_return_value = self.run_G(
                     gen_z, gen_c, update_emas=True)
-                if self.G.synthesis.data_camera_mode == 'shapenet_car' or self.G.synthesis.data_camera_mode == 'shapenet_chair' \
-                        or self.G.synthesis.data_camera_mode == 'shapenet_motorbike' or self.G.synthesis.data_camera_mode == 'renderpeople' or \
-                        self.G.synthesis.data_camera_mode == 'shapenet_plant' or self.G.synthesis.data_camera_mode == 'shapenet_vase' or \
-                        self.G.synthesis.data_camera_mode == 'ts_house' or self.G.synthesis.data_camera_mode == 'ts_animal' or \
-                        self.G.synthesis.data_camera_mode == 'all_shapenet':
-                    camera_condition = torch.cat((gen_camera[-2], gen_camera[-1]), dim=-1)
-                else:
-                    camera_condition = None
+
+                camera_condition = torch.cat((gen_camera[-2], gen_camera[-1]), dim=-1)
 
                 # Send it to discriminator
                 gen_logits = self.run_D(

--- a/training/networks_get3d.py
+++ b/training/networks_get3d.py
@@ -28,7 +28,6 @@ class DMTETSynthesisNetwork(torch.nn.Module):
             img_resolution,  # Output image resolution.
             img_channels,  # Number of color channels.
             device='cuda',
-            data_camera_mode='carla',
             geometry_type='normal',
             tet_res=64,  # Resolution for tetrahedron grid
             render_type='neural_render',  # neural type
@@ -52,7 +51,6 @@ class DMTETSynthesisNetwork(torch.nn.Module):
         self.deformation_multiplier = deformation_multiplier
         self.geometry_type = geometry_type
 
-        self.data_camera_mode = data_camera_mode
         self.n_freq_posenc_geo = 1
         self.render_type = render_type
 
@@ -318,7 +316,7 @@ class DMTETSynthesisNetwork(torch.nn.Module):
         '''
         sample_r = None
         world2cam_matrix, forward_vector, camera_origin, rotation_angle, elevation_angle = sample_camera(
-            self.data_camera_mode, batch_size * n_views, self.device)
+            batch_size * n_views, self.device)
         mv_batch = world2cam_matrix
         campos = camera_origin
         return campos.reshape(batch_size, n_views, 3), mv_batch.reshape(batch_size, n_views, 4, 4), \

--- a/training/sample_camera_distribution.py
+++ b/training/sample_camera_distribution.py
@@ -32,38 +32,17 @@ def create_camera_from_angle(phi, theta, sample_r, device='cuda'):
     return world2cam_matrix, forward_vector, camera_origin, phi, theta
 
 
-def sample_camera(camera_data_mode, n, device='cuda'):
+def sample_camera(n, device='cuda'):
     # We use this function to sample the camera for training the generator
     # When we're rendering the dataset, the camera is random sampled from
     # a uniform distribution (see `render_shapenet_data/render_shapenet.py`
     # for details of camera distribution)
-    if camera_data_mode == 'shapenet_car' or camera_data_mode == 'shapenet_chair' or camera_data_mode == 'shapenet_motorbike' \
-            or camera_data_mode == 'ts_house':
-        horizontal_stddev = math.pi  # here means horizontal rotation
-        vertical_stddev = (math.pi / 180) * 15
-        horizontal_mean = math.pi  ######## [horizon range [0, 2pi]]
-        vertical_mean = (math.pi / 180) * 75
-        mode = 'uniform'
-        radius_range = [1.2, 1.2]
-    elif camera_data_mode == 'ts_animal':
-        horizontal_stddev = math.pi  # here means horizontal rotation
-        vertical_stddev = (math.pi / 180) * (45.0 / 2.0)
-
-        horizontal_mean = math.pi  ######## [horizon range [0, 2pi]]
-        vertical_mean = (math.pi / 180) * ((90.0 + 90.0 - 45.0) / 2.0)
-        mode = 'uniform'
-        radius_range = [1.2, 1.2]
-    elif camera_data_mode == 'renderpeople':
-        horizontal_stddev = math.pi  # here means horizontal rotation
-        vertical_stddev = (math.pi / 180) * 10
-
-        horizontal_mean = math.pi  ######## [horizon range [0, 2pi]]
-        vertical_mean = (math.pi / 180) * 80
-        mode = 'uniform'
-        radius_range = [1.2, 1.2]
-
-    else:
-        raise NotImplementedError
+    horizontal_stddev = math.pi  # here means horizontal rotation
+    vertical_stddev = (math.pi / 180) * 15
+    horizontal_mean = math.pi  ######## [horizon range [0, 2pi]]
+    vertical_mean = (math.pi / 180) * 80
+    mode = 'uniform'
+    radius_range = [1.2, 1.2]
 
     camera_origin, rotation_angle, elevation_angle = sample_camera_positions(
         device, n=n, r=radius_range,


### PR DESCRIPTION
This is a PR to generalize handling of data sources. Currently the code makes assumptions that users will be using one of the provided training sets, but most likely people will want to evaluate on other training data or other parts of ShapeNet.

Changes the following things:
1. Removes if statements and dataset-specific logic
2. Change `data_camera_mode` to `manifest_dir` -- the main function is to find the training and val text files once any specific logic has been generalized.
3. Assume `use_shapenet_split` to always be true and remove the arg -- the other PR adds a script which properly splits data into 70/20/10 file manifests.
4. Update README to reflect changes (and fix a few typos also)

Submitted as a draft, I am testing on some datasets now to make sure everything is working.